### PR TITLE
Fix docs links from repository renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![github repo badge](https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/MiBiPreT/mibiscreen)
 [![github license badge](https://img.shields.io/github/license/MiBiPreT/mibiscreen)](https://github.com/MiBiPreT/mibiscreen)
 [![PyPI version](https://badge.fury.io/py/mibiscreen.svg)](https://badge.fury.io/py/mibiscreen)
-[![RSD](https://img.shields.io/badge/rsd-mibiscreen-00a3e3.svg)](https://www.research-software.nl/software/mibipret)
+[![RSD](https://img.shields.io/badge/rsd-mibiscreen-00a3e3.svg)](https://www.research-software.nl/software/mibiscreen)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10878799.svg)](https://doi.org/10.5281/zenodo.10878799)
 [![workflow cii badge](https://bestpractices.coreinfrastructure.org/projects/8711/badge)](https://bestpractices.coreinfrastructure.org/projects/8711)
 [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-green)](https://fair-software.eu)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-green)](https://fair-software.eu)
 [![workflow scq badge](https://sonarcloud.io/api/project_badges/measure?project=MiBiPreT_MiBiPreT&metric=alert_status)](https://sonarcloud.io/dashboard?id=MiBiPreT_MiBiPreT)
 [![workflow scc badge](https://sonarcloud.io/api/project_badges/measure?project=MiBiPreT_MiBiPreT&metric=coverage)](https://sonarcloud.io/dashboard?id=MiBiPreT_MiBiPreT)
-[![documentation](https://github.com/MiBiPreT/mibiscreen/actions/workflows/documentation-deploy.yml/badge.svg)](https://mibiscreen.github.io/mibiscreen)
+[![documentation](https://github.com/MiBiPreT/mibiscreen/actions/workflows/documentation-deploy.yml/badge.svg)](https://mibipret.github.io/mibiscreen)
 [![build](https://github.com/MiBiPreT/mibiscreen/actions/workflows/build.yml/badge.svg)](https://github.com/MiBiPreT/mibiscreen/actions/workflows/build.yml)
 [![cffconvert](https://github.com/MiBiPreT/mibiscreen/actions/workflows/cffconvert.yml/badge.svg)](https://github.com/MiBiPreT/mibiscreen/actions/workflows/cffconvert.yml)
 [![sonarcloud](https://github.com/MiBiPreT/mibiscreen/actions/workflows/sonarcloud.yml/badge.svg)](https://github.com/MiBiPreT/mibiscreen/actions/workflows/sonarcloud.yml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![github repo badge](https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue)](https://github.com/MiBiPreT/mibiscreen)
 [![github license badge](https://img.shields.io/github/license/MiBiPreT/mibiscreen)](https://github.com/MiBiPreT/mibiscreen)
 [![PyPI version](https://badge.fury.io/py/mibiscreen.svg)](https://badge.fury.io/py/mibiscreen)
-[![RSD](https://img.shields.io/badge/rsd-mibiscreen-00a3e3.svg)](https://www.research-software.nl/software/mibiscreen)
+[![RSD](https://img.shields.io/badge/rsd-mibiscreen-00a3e3.svg)](https://www.research-software.nl/software/mibipret)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10878799.svg)](https://doi.org/10.5281/zenodo.10878799)
 [![workflow cii badge](https://bestpractices.coreinfrastructure.org/projects/8711/badge)](https://bestpractices.coreinfrastructure.org/projects/8711)
 [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-green)](https://fair-software.eu)

--- a/mibiscreen/data/check_data.py
+++ b/mibiscreen/data/check_data.py
@@ -307,7 +307,7 @@ def check_units(data,
     if not test_unit:
         raise ValueError("Error: The second line in the dataframe is supposed\
                          to specify the units. No units were detected in this\
-                         line, check https://mibiscreen.github.io/mibiscreen/ Data\
+                         line, check https://mibipret.github.io/mibiscreen/ Data\
                          documentation.")
 
     # standardize column names (as it might not has happened for data yet)


### PR DESCRIPTION
This fixes an incorrect updating of the docs links. RSD links are now updated (thanks to @ewan-escience !).